### PR TITLE
Add test runner command for EditMode and PlayMode tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,8 @@ func Execute() error {
 		resp, err = menuCmd(subArgs, send)
 	case "reserialize":
 		resp, err = reserializeCmd(subArgs, send)
+	case "test":
+		resp, err = testCmd(subArgs, send, inst.Port)
 	default:
 		// Try as direct custom tool call
 		resp, err = send(category, map[string]interface{}{})
@@ -234,6 +236,16 @@ Profiler:
   profiler disable               Stop profiler recording
   profiler status                Show profiler state
   profiler clear                 Clear all captured frames
+
+Tests:
+  test [--mode EditMode|PlayMode]   Run tests (default: EditMode)
+  test --filter <name>                  Filter by namespace, class, or full test name
+
+  Examples:
+    test                                Run all EditMode tests
+    test --mode PlayMode            Run all PlayMode tests
+    test --filter MyNamespace.MyClass   Run a specific test class
+    test --mode EditMode --filter MyTest.SpecificTest
 
 Custom Tools:
   tool list                     List all registered tools (built-in + custom)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/youngwoocho02/unity-cli/internal/client"
+)
+
+type suppressWriter struct {
+	w        io.Writer
+	suppress string
+}
+
+func (s *suppressWriter) Write(p []byte) (int, error) {
+	if bytes.Contains(p, []byte(s.suppress)) {
+		return len(p), nil
+	}
+	return s.w.Write(p)
+}
+
+func testCmd(args []string, send sendFn, port int) (*client.CommandResponse, error) {
+	flags := parseSubFlags(args)
+
+	mode, ok := flags["mode"]
+	if !ok {
+		mode = "EditMode"
+	}
+
+	if mode != "EditMode" && mode != "PlayMode" {
+		return nil, fmt.Errorf("--mode must be EditMode or PlayMode, got: %s", mode)
+	}
+
+	params := map[string]interface{}{
+		"mode": mode,
+	}
+
+	if filter, ok := flags["filter"]; ok {
+		params["filter"] = filter
+	}
+
+	// No timeout — connection stays open for EditMode, file polling for PlayMode
+	flagTimeout = 0
+
+	resp, err := send("run_tests", params)
+	if err != nil {
+		return nil, err
+	}
+
+	// If Unity doesn't recognise the command, the Test Framework package is likely missing
+	if !resp.Success && strings.Contains(resp.Message, "Unknown command") {
+		return nil, fmt.Errorf(
+			"'run_tests' is not available.\n" +
+				"Make sure the Unity Test Framework package is installed:\n" +
+				"  Window → Package Manager → search 'Test Framework' → Install\n" +
+				"The UnityCliConnector.TestRunner assembly requires it to compile.")
+	}
+
+	// EditMode: results are in the response directly
+	if mode == "EditMode" {
+		return resp, nil
+	}
+
+	// PlayMode: Unity returns immediately with "running", we poll the results file
+	if resp.Message != "running" {
+		return resp, nil
+	}
+
+	fmt.Println("PlayMode tests running, waiting for results...")
+
+	// Domain reload is imminent — suppress the "Unsolicited response on idle HTTP channel"
+	// log line that fires when Unity kills the connection during reload.
+	original := log.Writer()
+	log.SetOutput(&suppressWriter{w: os.Stderr, suppress: "Unsolicited response received on idle HTTP channel"})
+	result, err := pollTestResults(port)
+	log.SetOutput(original)
+	return result, err
+}
+
+func pollTestResults(port int) (*client.CommandResponse, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	resultsPath := filepath.Join(home, ".unity-cli", "status", fmt.Sprintf("test-results-%d.json", port))
+
+	for {
+		data, err := os.ReadFile(resultsPath)
+		if err == nil {
+			// File exists — parse and return
+			os.Remove(resultsPath) // clean up
+			var resp client.CommandResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				return nil, fmt.Errorf("failed to parse test results: %w", err)
+			}
+			return &resp, nil
+		}
+
+		// File not there yet — check if Unity is still alive via its heartbeat
+		heartbeatPath := filepath.Join(home, ".unity-cli", "status", fmt.Sprintf("%d.json", port))
+		if _, err := os.Stat(heartbeatPath); os.IsNotExist(err) {
+			return nil, fmt.Errorf("Unity editor appears to have crashed — no heartbeat at port %d", port)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+

--- a/unity-connector/Editor/TestRunner.meta
+++ b/unity-connector/Editor/TestRunner.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4427fed874bc842a6b50fd366bfe5288
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-connector/Editor/TestRunner/RunTests.cs
+++ b/unity-connector/Editor/TestRunner/RunTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UnityCliConnector.TestRunner
+{
+    [UnityCliTool(Description = "Run Unity EditMode or PlayMode tests and return results.")]
+    public static class RunTests
+    {
+        static readonly string s_StatusDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".unity-cli", "status");
+
+        public class Parameters
+        {
+            [ToolParameter("Test mode to run: EditMode or PlayMode", Required = true)]
+            public string Mode { get; set; }
+
+            [ToolParameter("Optional test filter: namespace, class, or full test name")]
+            public string Filter { get; set; }
+        }
+
+        public static Task<object> HandleCommand(JObject @params)
+        {
+            if (@params == null)
+                return Task.FromResult<object>(new ErrorResponse("Parameters cannot be null."));
+
+            var p = new ToolParams(@params);
+
+            var modeResult = p.GetRequired("mode");
+            if (!modeResult.IsSuccess)
+                return Task.FromResult<object>(new ErrorResponse(modeResult.ErrorMessage));
+
+            var modeStr = modeResult.Value.Trim();
+            TestMode testMode;
+            if (modeStr.Equals("EditMode", StringComparison.OrdinalIgnoreCase))
+                testMode = TestMode.EditMode;
+            else if (modeStr.Equals("PlayMode", StringComparison.OrdinalIgnoreCase))
+                testMode = TestMode.PlayMode;
+            else
+                return Task.FromResult<object>(new ErrorResponse($"Unknown mode '{modeStr}'. Use EditMode or PlayMode."));
+
+            var filter = p.Get("filter", null);
+
+            // EditMode: no domain reload, hold connection and return results directly
+            if (testMode == TestMode.EditMode)
+                return ExecuteInProcess(testMode, filter);
+
+            // PlayMode: domain reload will kill the connection.
+            // Kick off the run, return immediately, Go polls the results file.
+            StartPlayModeRun(filter);
+            return Task.FromResult<object>(new SuccessResponse("running", new { port = HttpServer.Port }));
+        }
+
+        // --- EditMode path: hold connection open, return results when done ---
+
+        private static Task<object> ExecuteInProcess(TestMode mode, string filter)
+        {
+            var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var passed  = new List<string>();
+            var failed  = new List<string>();
+            var skipped = new List<string>();
+
+            var api = ScriptableObject.CreateInstance<TestRunnerApi>();
+
+            var callbacks = new Callbacks(
+                onTestResult: result =>
+                {
+                    if (result.Test.IsSuite) return;
+                    CollectResult(result, passed, failed, skipped);
+                },
+                onRunFinished: _ =>
+                {
+                    if (tcs.Task.IsCompleted) return;
+                    Object.DestroyImmediate(api);
+                    tcs.TrySetResult(BuildResponse(passed, failed, skipped));
+                }
+            );
+
+            api.RegisterCallbacks(callbacks);
+            api.Execute(new ExecutionSettings(BuildFilter(mode, filter)));
+            return tcs.Task;
+        }
+
+        // --- PlayMode path: fire and forget, write results to file after domain reload ---
+
+        private static void StartPlayModeRun(string filter)
+        {
+            var passed  = new List<string>();
+            var failed  = new List<string>();
+            var skipped = new List<string>();
+            var port    = HttpServer.Port;
+
+            // Clear any stale results file
+            var resultsPath = ResultsFilePath(port);
+            try { if (File.Exists(resultsPath)) File.Delete(resultsPath); } catch { }
+
+            // Write pending file so TestRunnerState can re-attach callbacks after domain reload
+            TestRunnerState.MarkPending(port, filter);
+
+            var api = ScriptableObject.CreateInstance<TestRunnerApi>();
+
+            var callbacks = new Callbacks(
+                onTestResult: result =>
+                {
+                    if (result.Test.IsSuite) return;
+                    CollectResult(result, passed, failed, skipped);
+                },
+                onRunFinished: _ =>
+                {
+                    Object.DestroyImmediate(api);
+                    TestRunnerState.ClearPending(port);
+                    WriteResultsFile(port, passed, failed, skipped);
+                }
+            );
+
+            api.RegisterCallbacks(callbacks);
+            api.Execute(new ExecutionSettings(BuildFilter(TestMode.PlayMode, filter)));
+        }
+
+        internal static void WriteResultsFile(int port, List<string> passed, List<string> failed, List<string> skipped)
+        {
+            var result = new
+            {
+                success  = failed.Count == 0,
+                message  = failed.Count > 0 ? $"{failed.Count} test(s) failed." : $"All {passed.Count} test(s) passed.",
+                data     = new
+                {
+                    total    = passed.Count + failed.Count + skipped.Count,
+                    passed   = passed.Count,
+                    failed   = failed.Count,
+                    skipped  = skipped.Count,
+                    failures = failed,
+                    passes   = passed,
+                }
+            };
+
+            try
+            {
+                Directory.CreateDirectory(s_StatusDir);
+                File.WriteAllText(ResultsFilePath(port), JsonConvert.SerializeObject(result));
+            }
+            catch { }
+        }
+
+        private static string ResultsFilePath(int port) =>
+            Path.Combine(s_StatusDir, $"test-results-{port}.json");
+
+        // --- Shared helpers ---
+
+        private static void CollectResult(ITestResultAdaptor result,
+            List<string> passed, List<string> failed, List<string> skipped)
+        {
+            var name   = result.Test.FullName;
+            var status = result.ResultState.ToString();
+            switch (status)
+            {
+                case "Passed":           passed.Add(name);  break;
+                case "Failed":
+                case "Error":            failed.Add($"{name}: {result.Message}"); break;
+                default:                 skipped.Add(name); break;
+            }
+        }
+
+        private static object BuildResponse(List<string> passed, List<string> failed, List<string> skipped)
+        {
+            var summary = new
+            {
+                total    = passed.Count + failed.Count + skipped.Count,
+                passed   = passed.Count,
+                failed   = failed.Count,
+                skipped  = skipped.Count,
+                failures = failed,
+                passes   = passed,
+            };
+            return failed.Count > 0
+                ? (object)new ErrorResponse($"{failed.Count} test(s) failed.", summary)
+                : new SuccessResponse($"All {passed.Count} test(s) passed.", summary);
+        }
+
+        private static Filter BuildFilter(TestMode mode, string filterStr)
+        {
+            var f = new Filter { testMode = mode };
+            if (!string.IsNullOrEmpty(filterStr))
+            {
+                f.testNames  = new[] { filterStr };
+                f.groupNames = new[] { filterStr };
+            }
+            return f;
+        }
+
+        private class Callbacks : ICallbacks
+        {
+            private readonly Action<ITestResultAdaptor> _onTestResult;
+            private readonly Action<ITestResultAdaptor> _onRunFinished;
+
+            public Callbacks(Action<ITestResultAdaptor> onTestResult, Action<ITestResultAdaptor> onRunFinished)
+            {
+                _onTestResult  = onTestResult;
+                _onRunFinished = onRunFinished;
+            }
+
+            public void RunStarted(ITestAdaptor testsToRun) { }
+            public void RunFinished(ITestResultAdaptor result) => _onRunFinished(result);
+            public void TestStarted(ITestAdaptor test) { }
+            public void TestFinished(ITestResultAdaptor result) => _onTestResult(result);
+        }
+    }
+}

--- a/unity-connector/Editor/TestRunner/RunTests.cs.meta
+++ b/unity-connector/Editor/TestRunner/RunTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9542c3c1b10543b2a786de17310d84c

--- a/unity-connector/Editor/TestRunner/TestRunnerState.cs
+++ b/unity-connector/Editor/TestRunner/TestRunnerState.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEditor.TestTools.TestRunner.Api;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace UnityCliConnector.TestRunner
+{
+    /// <summary>
+    /// Survives domain reloads via [InitializeOnLoad].
+    /// If a PlayMode test run was in progress when the domain reloaded,
+    /// re-registers callbacks so RunFinished still fires and writes results.
+    /// </summary>
+    [InitializeOnLoad]
+    public static class TestRunnerState
+    {
+        static readonly string s_StatusDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".unity-cli", "status");
+
+        static TestRunnerState()
+        {
+            AssemblyReloadEvents.afterAssemblyReload += OnAfterAssemblyReload;
+        }
+
+        /// <summary>
+        /// Called by RunTests before executing a PlayMode run.
+        /// Writes a pending file so we can re-attach after domain reload.
+        /// </summary>
+        public static void MarkPending(int port, string filter)
+        {
+            var pending = new { port, filter = filter ?? "" };
+            try
+            {
+                Directory.CreateDirectory(s_StatusDir);
+                File.WriteAllText(PendingFilePath(port), JsonConvert.SerializeObject(pending));
+            }
+            catch { }
+        }
+
+        public static void ClearPending(int port)
+        {
+            try
+            {
+                var path = PendingFilePath(port);
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch { }
+        }
+
+        static void OnAfterAssemblyReload()
+        {
+            // Find any pending file — port is encoded in filename
+            try
+            {
+                Directory.CreateDirectory(s_StatusDir);
+                foreach (var file in Directory.GetFiles(s_StatusDir, "test-pending-*.json"))
+                {
+                    var json = File.ReadAllText(file);
+                    var pending = JObject.Parse(json);
+                    var port   = pending["port"]?.Value<int>() ?? 0;
+                    var filter = pending["filter"]?.Value<string>();
+
+                    if (port == 0) continue;
+
+                    // Only re-attach if this is our port
+                    if (port != HttpServer.Port) continue;
+
+                    ReattachCallbacks(port, filter);
+                }
+            }
+            catch { }
+        }
+
+        static void ReattachCallbacks(int port, string filter)
+        {
+            var passed  = new List<string>();
+            var failed  = new List<string>();
+            var skipped = new List<string>();
+
+            var api = ScriptableObject.CreateInstance<TestRunnerApi>();
+
+            var callbacks = new Callbacks(
+                onTestResult: result =>
+                {
+                    if (result.Test.IsSuite) return;
+                    CollectResult(result, passed, failed, skipped);
+                },
+                onRunFinished: _ =>
+                {
+                    Object.DestroyImmediate(api);
+                    ClearPending(port);
+                    RunTests.WriteResultsFile(port, passed, failed, skipped);
+                }
+            );
+
+            api.RegisterCallbacks(callbacks);
+            // Don't call Execute again — the run is already in progress,
+            // we're just re-registering to receive the RunFinished callback.
+        }
+
+        static void CollectResult(ITestResultAdaptor result,
+            List<string> passed, List<string> failed, List<string> skipped)
+        {
+            var name   = result.Test.FullName;
+            var status = result.ResultState.ToString();
+            switch (status)
+            {
+                case "Passed":  passed.Add(name); break;
+                case "Failed":
+                case "Error":   failed.Add($"{name}: {result.Message}"); break;
+                default:        skipped.Add(name); break;
+            }
+        }
+
+        static string PendingFilePath(int port) =>
+            Path.Combine(s_StatusDir, $"test-pending-{port}.json");
+
+        private class Callbacks : ICallbacks
+        {
+            private readonly Action<ITestResultAdaptor> _onTestResult;
+            private readonly Action<ITestResultAdaptor> _onRunFinished;
+
+            public Callbacks(Action<ITestResultAdaptor> onTestResult, Action<ITestResultAdaptor> onRunFinished)
+            {
+                _onTestResult  = onTestResult;
+                _onRunFinished = onRunFinished;
+            }
+
+            public void RunStarted(ITestAdaptor testsToRun) { }
+            public void RunFinished(ITestResultAdaptor result) => _onRunFinished(result);
+            public void TestStarted(ITestAdaptor test) { }
+            public void TestFinished(ITestResultAdaptor result) => _onTestResult(result);
+        }
+    }
+}

--- a/unity-connector/Editor/TestRunner/TestRunnerState.cs.meta
+++ b/unity-connector/Editor/TestRunner/TestRunnerState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eb00d7ca0ba214643a1b94b2ffd5d9e9

--- a/unity-connector/Editor/TestRunner/UnityCliConnector.TestRunner.asmdef
+++ b/unity-connector/Editor/TestRunner/UnityCliConnector.TestRunner.asmdef
@@ -1,0 +1,24 @@
+{
+  "name": "UnityCliConnector.TestRunner",
+  "rootNamespace": "UnityCliConnector.TestRunner",
+  "references": [
+    "UnityCliConnector.Editor",
+    "UnityEditor.TestRunner"
+  ],
+  "includePlatforms": ["Editor"],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [
+    {
+      "name": "com.unity.test-framework",
+      "expression": "1.0.0",
+      "define": "UNITY_TEST_FRAMEWORK"
+    }
+  ],
+  "noEngineReferences": false,
+  "overridable": true
+}

--- a/unity-connector/Editor/TestRunner/UnityCliConnector.TestRunner.asmdef.meta
+++ b/unity-connector/Editor/TestRunner/UnityCliConnector.TestRunner.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 08670550fc00648ce9c9849bae51308b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Add `unity-cli test` command for running EditMode and PlayMode tests

Adds a new `test` command that runs Unity's Test Runner from the CLI and returns structured pass/fail results.

## Usage

```
unity-cli test                                        # EditMode (default)
unity-cli test --mode PlayMode                        # PlayMode
unity-cli test --filter BallControllerEditModeTests   # filter by class or full test name
```

## How it works

EditMode tests hold the HTTP connection open until `RunFinished` fires, then return results directly — same pattern as `editor play --wait`.

PlayMode tests require a different approach due to Unity's domain reload. When entering PlayMode, Unity tears down and rebuilds the C# domain, which kills the HTTP connection and destroys any in-flight ScriptableObjects including the `TestRunnerApi` instance. A held connection would never get a response.

The solution decouples the run from the response:

1. `run_tests` kicks off the PlayMode run, writes a `test-pending-{port}.json` state file, and returns `"running"` immediately before the domain reload hits
2. Go polls `~/.unity-cli/status/test-results-{port}.json` every 500ms, also checking the heartbeat file to detect editor crashes
3. A new `[InitializeOnLoad]` class `TestRunnerState` fires after every assembly reload, detects the pending file, and re-registers callbacks on a fresh `TestRunnerApi` instance — it does not call `Execute` again, just re-attaches to the already-running test session
4. When `RunFinished` fires (on either side of the reload), results are written to the results file, the pending file is cleaned up, and Go reads and returns the results

The "Unsolicited response received on idle HTTP channel" log line that Go's `net/http` emits when Unity drops the connection during reload is suppressed surgically — only during the PlayMode polling window, restored immediately after.

## New files

- `unity-connector/Editor/TestRunner/RunTests.cs` — the `[UnityCliTool]` handler
- `unity-connector/Editor/TestRunner/TestRunnerState.cs` — domain reload survival via `[InitializeOnLoad]`
- `unity-connector/Editor/TestRunner/UnityCliConnector.TestRunner.asmdef` — separate asmdef with optional dependency on `com.unity.test-framework`, gracefully absent if package not installed
- `cmd/test.go` — Go command

## Notes

- If the Test Framework package is not installed, the asmdef won't compile and the tool won't register. The CLI surfaces a clear error message pointing to Package Manager rather than a cryptic "Unknown command"
- No timeout on either side — runs until done or editor crashes