### PR TITLE
fix: prefer CWD match over timestamp when discovering Unity instance

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -118,6 +118,17 @@ func DiscoverInstance(project string, port int) (*Instance, error) {
 		return nil, fmt.Errorf("no Unity instance found for project: %s", project)
 	}
 
+	// Try to match by current working directory before falling back to timestamp
+	if cwd, err := os.Getwd(); err == nil {
+		cwdNorm := filepath.ToSlash(cwd)
+		for _, inst := range alive {
+			projNorm := filepath.ToSlash(inst.ProjectPath)
+			if cwdNorm == projNorm || strings.HasPrefix(cwdNorm, projNorm+"/") {
+				return &inst, nil
+			}
+		}
+	}
+
 	// Return the most recently updated
 	best := alive[0]
 	for _, inst := range alive[1:] {


### PR DESCRIPTION
When multiple Unity editors are open, DiscoverInstance falls back to the most recently updated heartbeat timestamp, causing random cross- project connections since both editors write every 0.5s.

Now checks if the current working directory falls inside a registered project path before falling back to timestamp-based selection.