### PR TITLE
fix: normalize --project path matching on Windows

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -152,8 +153,9 @@ func DiscoverInstance(project string, port int) (*Instance, error) {
 	}
 
 	if project != "" {
+		projectNorm := normalizeProjectPath(project)
 		for _, inst := range alive {
-			if strings.Contains(inst.ProjectPath, project) {
+			if strings.Contains(normalizeProjectPath(inst.ProjectPath), projectNorm) {
 				return &inst, nil
 			}
 		}
@@ -179,6 +181,20 @@ func DiscoverInstance(project string, port int) (*Instance, error) {
 		}
 	}
 	return &best, nil
+}
+
+// normalizeProjectPath makes project path matching stable across platforms.
+// It normalizes slashes, trims trailing separators, and on Windows lowercases
+// the path so --project matching is case-insensitive.
+func normalizeProjectPath(path string) string {
+	normalized := filepath.ToSlash(strings.TrimSpace(path))
+	for len(normalized) > 1 && strings.HasSuffix(normalized, "/") {
+		normalized = strings.TrimSuffix(normalized, "/")
+	}
+	if runtime.GOOS == "windows" {
+		normalized = strings.ToLower(normalized)
+	}
+	return normalized
 }
 
 func Send(inst *Instance, command string, params interface{}, timeoutMs int) (*CommandResponse, error) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -18,9 +18,13 @@ func stubIsProcessDead(t *testing.T, deadPIDs map[int]bool) {
 	t.Cleanup(func() { isProcessDead = orig })
 }
 
+// writeInstanceFiles creates isolated instance files and points both HOME and
+// USERPROFILE to the temp directory so tests never read real local instances.
 func writeInstanceFiles(t *testing.T, files map[string]Instance) string {
 	t.Helper()
 	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	dir := filepath.Join(home, ".unity-cli", "instances")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		t.Fatalf("failed to create instances dir: %v", err)
@@ -272,5 +276,55 @@ func TestScanInstances_KeepsZeroPID(t *testing.T) {
 	}
 	if len(instances) != 1 {
 		t.Fatalf("expected 1 instance, got %d", len(instances))
+	}
+}
+
+// TestDiscoverInstance_ProjectPathMatchesSlashVariants verifies --project can
+// match Windows-style backslashes against Unity's forward-slash projectPath.
+func TestDiscoverInstance_ProjectPathMatchesSlashVariants(t *testing.T) {
+	stubIsProcessDead(t, map[int]bool{})
+
+	home := writeInstanceFiles(t, map[string]Instance{
+		"project.json": {
+			State:       "ready",
+			ProjectPath: "E:/GamerAworlD",
+			Port:        8090,
+			PID:         100,
+			Timestamp:   1000,
+		},
+	})
+	t.Setenv("HOME", home)
+
+	got, err := DiscoverInstance(`E:\GamerAworlD`, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ProjectPath != "E:/GamerAworlD" {
+		t.Errorf("ProjectPath: got %q, want %q", got.ProjectPath, "E:/GamerAworlD")
+	}
+}
+
+// TestDiscoverInstance_ProjectPathMatchesCaseInsensitiveOnWindows verifies
+// --project matching ignores path letter casing on Windows.
+func TestDiscoverInstance_ProjectPathMatchesCaseInsensitiveOnWindows(t *testing.T) {
+	stubIsProcessDead(t, map[int]bool{})
+
+	home := writeInstanceFiles(t, map[string]Instance{
+		"project.json": {
+			State:       "ready",
+			ProjectPath: "E:/GamerAworlD",
+			Port:        8090,
+			PID:         100,
+			Timestamp:   1000,
+		},
+	})
+	t.Setenv("HOME", home)
+
+	got, err := DiscoverInstance("e:/gameraworld", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ProjectPath != "E:/GamerAworlD" {
+		t.Errorf("ProjectPath: got %q, want %q", got.ProjectPath, "E:/GamerAworlD")
 	}
 }


### PR DESCRIPTION
﻿## Summary
- Fix `--project` matching in `DiscoverInstance` by normalizing both the CLI input path and Unity instance `projectPath` before comparison.
- Normalize slash style and trailing separators, and use case-insensitive matching on Windows.
- Add regression tests for slash-variant and case-variant path inputs.

## Problem
On Windows, the Unity connector commonly reports project paths in forward-slash format (for example `C:/Projects/MyGame`), while users often pass `--project` with backslashes or different casing (for example `C:\Projects\MyGame`).

Before this change, matching used a raw `strings.Contains(inst.ProjectPath, project)` check, which could fail for equivalent Windows paths.

## Behavior Before
- Stored path: `C:/Projects/MyGame`
- Input path: `C:\Projects\MyGame`
- Result: `no Unity instance found for project`

## Behavior After
### Example 1: Slash variant
```bash
unity-cli --project "C:\Projects\MyGame" status
```
Now correctly matches an instance reporting `C:/Projects/MyGame`.

### Example 2: Case variant on Windows
```bash
unity-cli --project "c:/projects/mygame" status
```
Now correctly matches `C:/Projects/MyGame`.

## Implementation Notes
- Added `normalizeProjectPath()` in `internal/client/client.go`.
- Normalization includes:
  - slash normalization via `filepath.ToSlash`
  - trimming trailing `/`
  - lowercasing on Windows (`runtime.GOOS == "windows"`)

## Tests
- Added regression tests in `internal/client/client_test.go`:
  - `TestDiscoverInstance_ProjectPathMatchesSlashVariants`
  - `TestDiscoverInstance_ProjectPathMatchesCaseInsensitiveOnWindows`
- Verified:
  - `go test ./internal/client` passes

## Risks
- Matching remains substring-based by design; this change only improves normalization and Windows compatibility.
