### PR TITLE
fix: --port hangs on "Waiting for Unity..." because resolver returns Timestamp=0

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -125,11 +125,16 @@ func FindActiveByPort(port int) (*Instance, error) {
 }
 
 // DiscoverInstance finds a running Unity instance from ~/.unity-cli/instances/.
-// If port > 0, skips discovery and connects directly.
+// If port > 0, returns the matching active instance file when present (so
+// callers like waitForAlive see a real Timestamp); otherwise falls back to a
+// stub so the user can still target a port that has no heartbeat yet.
 // If project is set, matches by project path substring.
 // Otherwise returns the most recently active instance.
 func DiscoverInstance(project string, port int) (*Instance, error) {
 	if port > 0 {
+		if inst, err := FindActiveByPort(port); err == nil {
+			return inst, nil
+		}
 		return &Instance{ProjectPath: "override", Port: port}, nil
 	}
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -307,3 +307,57 @@ func TestDiscoverInstance_ProjectPathMatchesSlashVariants(t *testing.T) {
 		t.Errorf("ProjectPath: got %q, want %q", got.ProjectPath, "E:/GamerAworlD")
 	}
 }
+
+// TestDiscoverInstance_PortFlagPopulatesTimestamp verifies that --port lookups
+// return the actual instance file's timestamp when one exists. Without this,
+// waitForAlive sees Timestamp=0 and polls indefinitely for a "newer" heartbeat
+// that never arrives, hanging on "Waiting for Unity..." until --timeout expires.
+func TestDiscoverInstance_PortFlagPopulatesTimestamp(t *testing.T) {
+	stubIsProcessDead(t, map[int]bool{})
+
+	home := writeInstanceFiles(t, map[string]Instance{
+		"current.json": {
+			State:       "ready",
+			ProjectPath: "/projects/current",
+			Port:        8091,
+			PID:         200,
+			Timestamp:   12345,
+		},
+	})
+	t.Setenv("HOME", home)
+
+	got, err := DiscoverInstance("", 8091)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Port != 8091 {
+		t.Errorf("Port: got %d, want %d", got.Port, 8091)
+	}
+	if got.Timestamp != 12345 {
+		t.Errorf("Timestamp: got %d, want %d (override stub leaks instead of file timestamp)", got.Timestamp, 12345)
+	}
+	if got.ProjectPath != "/projects/current" {
+		t.Errorf("ProjectPath: got %q, want %q", got.ProjectPath, "/projects/current")
+	}
+}
+
+// TestDiscoverInstance_PortFlagFallsBackToStub verifies that --port still
+// works when no matching instance file exists (e.g., connecting to a Unity
+// instance before its heartbeat has been written).
+func TestDiscoverInstance_PortFlagFallsBackToStub(t *testing.T) {
+	stubIsProcessDead(t, map[int]bool{})
+
+	home := writeInstanceFiles(t, map[string]Instance{})
+	t.Setenv("HOME", home)
+
+	got, err := DiscoverInstance("", 8091)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Port != 8091 {
+		t.Errorf("Port: got %d, want %d", got.Port, 8091)
+	}
+	if got.ProjectPath != "override" {
+		t.Errorf("ProjectPath: got %q, want %q", got.ProjectPath, "override")
+	}
+}


### PR DESCRIPTION
## Summary

- \`unity-cli --port <N> <command>\` hangs at \`Waiting for Unity...\` until \`--timeout\` expires, even when the connector is fully healthy.
- Root cause: \`DiscoverInstance(_, port)\` returns a stub \`Instance{ProjectPath: "override", Port: port}\` with \`Timestamp = 0\`. After ac52bfd refactored \`waitForAlive\` to use the resolver's \`Timestamp\` as the freshness baseline (instead of reading the file directly via \`readActiveStatus\`), the stub's zero timestamp makes the freshness check \`now - 0 < 1000\` always false, and the polling loop keeps re-resolving the same \`Timestamp=0\` so \`inst.Timestamp > baseline\` is also always false. The wait never returns.
- The HTTP listener and heartbeat are both healthy during the hang — \`curl\` directly to the port works. Only the CLI's pre-send wait blocks.
- Fix: when \`--port\` is given and an active instance file matches that port, return the real instance (with its actual \`Timestamp\`). Fall back to the stub only when no file matches, preserving the "connect to a port whose heartbeat hasn't been written yet" use case.

## Test plan

- [x] Added \`TestDiscoverInstance_PortFlagPopulatesTimestamp\` — fails on \`main\` (returns \`Timestamp=0\`), passes after the fix.
- [x] Added \`TestDiscoverInstance_PortFlagFallsBackToStub\` — verifies the no-file edge case still returns the override stub.
- [x] Existing \`TestWaitForAlive_FollowsResolverPortChange\` continues to pass (resolver contract unchanged when callers construct their own Instance values).
- [ ] Manual: \`unity-cli --port 8091 editor play\` against a live Unity returns immediately instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)