### PR TITLE
fix(connector): auto-recover when HTTP listener dies

### DIFF
--- a/unity-connector/Editor/CommandRouter.cs
+++ b/unity-connector/Editor/CommandRouter.cs
@@ -13,19 +13,32 @@ namespace UnityCliConnector
     /// </summary>
     public static class CommandRouter
     {
-        static readonly SemaphoreSlim s_Lock = new(1, 1);
+        static SemaphoreSlim s_Lock = new(1, 1);
 
         public static async Task<object> Dispatch(string command, JObject parameters)
         {
-            await s_Lock.WaitAsync();
+            // Capture locally so a concurrent ResetLock() swap doesn't make us release a
+            // semaphore we never acquired. A still-running orphaned call releases the old
+            // semaphore (now unreferenced) instead of double-releasing the new one.
+            var sem = s_Lock;
+            await sem.WaitAsync();
             try
             {
                 return await DispatchInternal(command, parameters);
             }
             finally
             {
-                s_Lock.Release();
+                sem.Release();
             }
+        }
+
+        /// <summary>
+        /// Replaces the dispatch semaphore with a fresh one so new commands can run
+        /// even if a previous handler is still hung holding the old semaphore.
+        /// </summary>
+        public static void ResetLock()
+        {
+            s_Lock = new SemaphoreSlim(1, 1);
         }
 
         static async Task<object> DispatchInternal(string command, JObject parameters)

--- a/unity-connector/Editor/Heartbeat.cs
+++ b/unity-connector/Editor/Heartbeat.cs
@@ -60,7 +60,9 @@ namespace UnityCliConnector
 
         static void Tick()
         {
-            if (HttpServer.Port == 0) return;
+            // Stop writing once the listener is down so MarkStopped's "stopped" state
+            // isn't immediately overwritten by a fresh live snapshot.
+            if (!HttpServer.IsRunning) return;
 
             var now = EditorApplication.timeSinceStartup;
             if (now - s_LastWrite < INTERVAL) return;

--- a/unity-connector/Editor/Heartbeat.cs
+++ b/unity-connector/Editor/Heartbeat.cs
@@ -133,7 +133,9 @@ namespace UnityCliConnector
             return "ready";
         }
 
-        public static void Cleanup()
+        public static void Cleanup() => MarkStopped();
+
+        public static void MarkStopped()
         {
             if (HttpServer.Port == 0) return;
             s_ForcedState = "stopped";

--- a/unity-connector/Editor/HttpServer.cs
+++ b/unity-connector/Editor/HttpServer.cs
@@ -24,10 +24,15 @@ namespace UnityCliConnector
     {
         const int DEFAULT_PORT = 8090;
         const int MAX_PORT_ATTEMPTS = 10;
+        const double AUTO_RESTART_INTERVAL = 1.0;
+        const double FAILURE_LOG_INTERVAL = 5.0;
 
         static HttpListener s_Listener;
         static CancellationTokenSource s_Cts;
         static int s_Port;
+        static double s_NextStartAttemptTime;
+        static string s_LastFailureMessage;
+        static double s_LastFailureLogTime;
 
         static readonly ConcurrentQueue<WorkItem> s_Queue = new();
 
@@ -48,40 +53,83 @@ namespace UnityCliConnector
         }
 
         public static int Port => s_Port;
+        public static bool IsRunning => s_Listener != null && s_Listener.IsListening;
 
         static void Start()
         {
-            if (s_Listener != null) return;
+            if (IsRunning) return;
+            // Stale listener left behind by a crashed ListenLoop — tear it down before rebinding.
+            if (s_Listener != null) StopListener();
 
             for (var attempt = 0; attempt < MAX_PORT_ATTEMPTS; attempt++)
             {
                 var port = DEFAULT_PORT + attempt;
-                try
-                {
-                    var listener = new HttpListener();
-                    listener.Prefixes.Add($"http://127.0.0.1:{port}/");
-                    listener.Start();
-
-                    s_Listener = listener;
-                    s_Port = port;
-                    s_Cts = new CancellationTokenSource();
-
-                    _ = ListenLoop(s_Cts.Token);
-
-                    Debug.Log($"[UnityCliConnector] HTTP server started on port {port}");
+                if (TryStartOnPort(port))
                     return;
-                }
-                catch (HttpListenerException)
-                {
-                    // Port in use, try next
-                }
-                catch (System.Net.Sockets.SocketException)
-                {
-                    // Windows/Mono throws SocketException instead of HttpListenerException
-                }
             }
 
-            Debug.LogError("[UnityCliConnector] Failed to start HTTP server — no available port");
+            Heartbeat.MarkStopped();
+            ScheduleRetry();
+            LogStartFailure("[UnityCliConnector] Failed to start HTTP server — no available port", true);
+        }
+
+        static bool TryStartOnPort(int port)
+        {
+            try
+            {
+                var listener = new HttpListener();
+                listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+                listener.Start();
+
+                s_Listener = listener;
+                s_Port = port;
+                s_Cts = new CancellationTokenSource();
+                s_NextStartAttemptTime = 0;
+                ClearStartFailure();
+
+                _ = ListenLoop(s_Cts.Token);
+
+                Debug.Log($"[UnityCliConnector] HTTP server started on port {port}");
+                return true;
+            }
+            catch (HttpListenerException)
+            {
+                return false;
+            }
+            catch (System.Net.Sockets.SocketException)
+            {
+                // Windows/Mono throws SocketException instead of HttpListenerException
+                return false;
+            }
+            catch (Exception ex)
+            {
+                ScheduleRetry();
+                LogStartFailure($"[UnityCliConnector] Failed to start HTTP server on port {port}: {ex.Message}", true);
+                return false;
+            }
+        }
+
+        static void ScheduleRetry()
+        {
+            s_NextStartAttemptTime = EditorApplication.timeSinceStartup + AUTO_RESTART_INTERVAL;
+        }
+
+        static void LogStartFailure(string message, bool error = false)
+        {
+            var now = EditorApplication.timeSinceStartup;
+            if (s_LastFailureMessage == message && now - s_LastFailureLogTime < FAILURE_LOG_INTERVAL)
+                return;
+
+            s_LastFailureMessage = message;
+            s_LastFailureLogTime = now;
+            if (error) Debug.LogError(message);
+            else Debug.LogWarning(message);
+        }
+
+        static void ClearStartFailure()
+        {
+            s_LastFailureMessage = null;
+            s_LastFailureLogTime = 0;
         }
 
         static void StopListener()
@@ -108,6 +156,7 @@ namespace UnityCliConnector
         {
             var port = s_Port;
             StopListener();
+            Heartbeat.MarkStopped();
             Debug.Log($"[UnityCliConnector] HTTP server stopped (was port {port})");
         }
 
@@ -119,6 +168,10 @@ namespace UnityCliConnector
 
         static void ProcessQueue()
         {
+            // Watchdog: recover if the listener died unexpectedly between assembly reloads.
+            if (!IsRunning && EditorApplication.timeSinceStartup >= s_NextStartAttemptTime)
+                Start();
+
             while (s_Queue.TryDequeue(out var item))
                 ProcessItem(item);
         }
@@ -138,20 +191,41 @@ namespace UnityCliConnector
 
         static async Task ListenLoop(CancellationToken ct)
         {
-            while (ct.IsCancellationRequested == false && s_Listener?.IsListening == true)
+            try
             {
-                try
+                while (!ct.IsCancellationRequested)
                 {
-                    var context = await s_Listener.GetContextAsync();
-                    _ = HandleRequest(context);
+                    var listener = s_Listener;
+                    if (listener == null || !listener.IsListening) break;
+
+                    try
+                    {
+                        var context = await listener.GetContextAsync();
+                        _ = HandleRequest(context);
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (HttpListenerException)
+                    {
+                        break;
+                    }
                 }
-                catch (ObjectDisposedException)
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[UnityCliConnector] ListenLoop crashed: {ex.Message}");
+            }
+            finally
+            {
+                // If we exited without an explicit cancel, clean up so the watchdog can restart.
+                if (!ct.IsCancellationRequested && s_Listener != null)
                 {
-                    break;
-                }
-                catch (HttpListenerException)
-                {
-                    break;
+                    Debug.LogWarning("[UnityCliConnector] ListenLoop exited unexpectedly — cleaning up for auto-recovery");
+                    try { s_Listener.Stop(); s_Listener.Close(); } catch { }
+                    s_Listener = null;
+                    Heartbeat.MarkStopped();
                 }
             }
         }


### PR DESCRIPTION
## Summary

The Unity-side HTTP listener has several dead-state scenarios that
currently require an Editor restart to recover from. This PR makes
the connector self-heal in all of them.

### Failure scenarios fixed

1. **Zombie listener.** `Start()` early-returns on `s_Listener != null`,
   so if `ListenLoop` exits without nulling the reference (e.g.
   exception path), every subsequent call is a no-op until Unity
   restarts.
2. **`ListenLoop` exits unexpectedly.** Caught exceptions `break` out
   of the loop without clearing `s_Listener`, producing scenario 1.
3. **Initial port-in-use is fatal.** If all 10 ports fail at startup,
   the connector logs an error and gives up forever.
4. **Hung command handler holds `CommandRouter`'s semaphore.** Because
   the lock is `static readonly`, restarting the HTTP server doesn't
   release it — the only recovery is restarting Unity.

### Changes

- `HttpServer.IsRunning` checks the listener actually listens.
  `Start()` tears down a stale reference before rebinding.
- `ListenLoop` has a `finally` block that cleans up state if the loop
  exits without an explicit cancel.
- `ProcessQueue` watchdog: when `!IsRunning`, calls `Start()`
  (rate-limited via `AUTO_RESTART_INTERVAL = 1s`). Failure logging is
  rate-limited via `FAILURE_LOG_INTERVAL = 5s` to avoid console spam.
- `CommandRouter.Dispatch` captures the semaphore in a local so a
  future `ResetLock()` swap can't make in-flight calls double-release
  the new semaphore. `ResetLock()` is exposed for future recovery
  surfaces.
- `Heartbeat.MarkStopped()` lets failure paths flag the heartbeat as
  dead so the CLI sees an honest "not responding" state.

### Notes

- `ResetLock()` has no caller in this PR. It's the recovery hook for a
  follow-up that adds a status window / CLI command to purge hung
  handlers without restarting Unity. Happy to drop it if you'd rather
  land the API alongside its caller.
- A second PR will follow with port persistence (preferred-port file
  so the listener rebinds to the same port across restarts, keeping
  any running CLI client's instance reference valid).

## Test plan

- [ ] Open Unity, confirm connector starts and `unity-cli status`
      returns `ready`.
- [ ] Force a listener crash (e.g. patch `ListenLoop` to throw) and
      verify `[UnityCliConnector] ListenLoop exited unexpectedly` log
      followed by an automatic restart within ~1s.
- [ ] Hold port 8090..8099 from another process before opening Unity;
      verify rate-limited "no available port" warning every 5s and
      automatic recovery once a port frees up.
- [ ] `go test ./...` passes (no Go-side changes).